### PR TITLE
testname update

### DIFF
--- a/common/models/lab/Testname.php
+++ b/common/models/lab/Testname.php
@@ -10,6 +10,7 @@ use Yii;
  * @property int $testname_id
  * @property string $testName
  * @property int $status_id
+ * @property string $max_storage 
  * @property string $create_time
  * @property string $update_time
  *
@@ -41,6 +42,7 @@ class Testname extends \yii\db\ActiveRecord
         return [
             [['testName', 'status_id'], 'required'],
             [['status_id'], 'integer'],
+            [['max_storage'], 'number'], 
             [['create_time', 'update_time'], 'safe'],
             [['testName'], 'string', 'max' => 200],
         ];
@@ -55,6 +57,7 @@ class Testname extends \yii\db\ActiveRecord
             'testname_id' => 'Testname ID',
             'testName' => 'Test Name',
             'status_id' => 'Status',
+            'max_storage' => 'Recommended Max Storage [hours(H)]',
             'create_time' => 'Create Time',
             'update_time' => 'Update Time',
         ];

--- a/frontend/modules/lab/views/testname/_form.php
+++ b/frontend/modules/lab/views/testname/_form.php
@@ -22,14 +22,21 @@ use yii\helpers\Url;
     <?php
         $model->status_id='Active';
     ?>
-    <?= $form->field($model,'status_id')->widget(Select2::classname(),[
+    <div class="row">
+        <div class="col-md-6">
+            <?= $form->field($model,'status_id')->widget(Select2::classname(),[
                     'data' => ['1'=>'Active', '0'=>'Inactive'],
                     'theme' => Select2::THEME_KRAJEE,
                     'options' => ['id'=>'sample-testcategory_id'],
                     'pluginOptions' => ['allowClear' => true],
             ])
-    ?>
-
+            ?>
+        </div>
+        <div class="col-md-6">
+            <?= $form->field($model, 'max_storage')->textInput(['maxlength' => true]) ?>
+        </div>
+    </div>
+    
     <div class="row">
              <div class="col-md-6">
              <?= $form->field($model, 'create_time')->textInput(['readonly' => true]) ?>

--- a/frontend/modules/lab/views/testname/index.php
+++ b/frontend/modules/lab/views/testname/index.php
@@ -45,6 +45,7 @@ $this->params['breadcrumbs'][] = $this->title;
                     
                 },
             ],
+            'max_storage',
             'create_time',
             'update_time',
 


### PR DESCRIPTION
added new field "max_storage" to accomodate the workload feature

NOTE: new  field
"max_storage", type = decimal,  length="11,2" , not required